### PR TITLE
Change installation command to use pipx

### DIFF
--- a/memomemo.md
+++ b/memomemo.md
@@ -67,7 +67,7 @@ If Pandoc LaTeX environment is available, and you include `awesomebox` in your `
 Installation is easy, just:
 
 ```
- pip install pandoc-latex-environment
+ pipx install pandoc-latex-environment
 ```
 
 \newpage


### PR DESCRIPTION
Ubuntu 23.04+ and other modern distributions implement PEP 668, which marks the system Python installation as "externally managed." This  prevents 'pip install' from running globally to avoid dependency  conflicts with system-critical packages.

Using pipx is the recommended solution because it:
1. Creates an isolated virtual environment for the package automatically.
2. Exposes the 'pandoc-latex-environment' executable to the user's PATH.
3. Prevents potential breakage of the OS-level Python environment.