### PR TITLE
Add repo root to include paths

### DIFF
--- a/bin/memo
+++ b/bin/memo
@@ -165,8 +165,10 @@ PREPROCESSED_MD="${BASENAME}_preprocessed.md"
 LOG_FILE="${BASENAME}_processing.log"
 (( INFO )) && : >"$LOG_FILE"
 
-BASE_PATH=$(realpath -m "$0/../..")
-export TEXINPUTS=".:$BASE_PATH:"
+BASE_PATH=$(dirname "$(readlink -f "$0")")/..
+
+export TEXINPUTS="$BASE_PATH:"
+
 M4_PARAMS+=(
   "--include=$BASE_PATH"
   "-D__DATE__=$D" "-D__TIME__=$T" "-D__BRANCH__=$BRANCH"

--- a/bin/memo
+++ b/bin/memo
@@ -165,7 +165,10 @@ PREPROCESSED_MD="${BASENAME}_preprocessed.md"
 LOG_FILE="${BASENAME}_processing.log"
 (( INFO )) && : >"$LOG_FILE"
 
+BASE_PATH=$(realpath -m "$0/../..")
+export TEXINPUTS=".:$BASE_PATH:"
 M4_PARAMS+=(
+  "--include=$BASE_PATH"
   "-D__DATE__=$D" "-D__TIME__=$T" "-D__BRANCH__=$BRANCH"
   "-D__REVISION__=$REVISION" "-D__TAG__=$TAG" "-D__FILENAME__=$ABS_MD"
 )
@@ -231,10 +234,10 @@ pandoc_common=(
 ###############################################################################
 # 9 – Build flow
 ###############################################################################
+
 if (( GLOSSARY || NOMENCL || FORCE_TEX )); then
   # 9a – TeX intermediate path
   quiet_or_log pandoc "${pandoc_common[@]}" --extract-media=mermaid-img -o "${BASENAME}.tex"
-
   run_xelatex "${BASENAME}.tex"        # pass 1
 
   if (( GLOSSARY || NOMENCL )); then


### PR DESCRIPTION
This PR adds the memo repo root to the M4 and latex include paths, so the script can be called from other directories.

In particular:
- m4, so we can include the default `.frontmatter`
- latex, to resolve the `backgrounds/background.pdf` file.

I did this in my local to add memo/bin to my PATH, and then be able to call the script from any directory