### PR TITLE
Fix mv self-move failure on Linux in TeX build path

### DIFF
--- a/bin/memo
+++ b/bin/memo
@@ -263,8 +263,6 @@ if (( GLOSSARY || NOMENCL || FORCE_TEX )); then
     run_xelatex "${BASENAME}.tex"      # pass 2
     run_xelatex "${BASENAME}.tex"      # pass 3
   fi
-
-  mv "${BASENAME}.pdf" "$PDF"
 else
   # 9b – Direct Pandoc → PDF
   quiet_or_log pandoc "${pandoc_common[@]}" -o "$PDF"


### PR DESCRIPTION
PDF is always "${BASENAME}.pdf", assigned in line 170.

On macOS, the move is a no-op, but it fails on Linux, this fix just removes the `mv` command. 

Another fix could be to do nothing if the files are the same,  but it would be a check that is always true, unless it is there for when/if we want to pass the PDF write route as an argument.

## Test plan
- [x] Run ./bin/memo --tex memomemo.md on Linux (TeX path; previously hit the mv error)
